### PR TITLE
Upgrade to Boot 2.0.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.analytics</groupId>
 	<artifactId>spring-analytics</artifactId>
-	<version>1.1.4.BUILD-SNAPSHOT</version>
+	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<name>spring-analytics</name>
 	<description>Contains APIs for interacting with analytics</description>
 	<url>https://github.com/spring-projects/spring-analytics</url>
@@ -42,20 +42,19 @@
 	</prerequisites>
 
 	<properties>
-		<spring.boot.version>1.3.5.RELEASE</spring.boot.version>
+		<spring.boot.version>2.0.0.RELEASE</spring.boot.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>1.4.1.RELEASE</version>
+				<version>2.0.0.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
 
 	<issueManagement>
 		<system>GitHub</system>
@@ -65,7 +64,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -126,8 +125,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/springframework/analytics/metrics/redis/RedisMetricRepository.java
+++ b/src/main/java/org/springframework/analytics/metrics/redis/RedisMetricRepository.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.analytics.metrics.redis;
+
+import org.springframework.analytics.rest.domain.Delta;
+import org.springframework.analytics.rest.domain.Metric;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.BoundZSetOperations;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.util.Assert;
+
+import java.util.*;
+
+/**
+ * Redis implementation of metric information. Metric values are stored
+ * as zset values plus a regular hash value for the timestamp, both against a key composed
+ * of the metric name prefixed with a constant (default "spring.metrics."). If you have
+ * multiple metrics repositories all point at the same instance of Redis, it may be useful
+ * to change the prefix to be unique (but not if you want them to contribute to the same
+ * metrics).
+ *
+ * @author Dave Syer
+ */
+public class RedisMetricRepository {
+
+	private static final String DEFAULT_METRICS_PREFIX = "spring.metrics.";
+
+	private static final String DEFAULT_KEY = "keys.spring.metrics";
+
+	private String prefix = DEFAULT_METRICS_PREFIX;
+
+	private String key = DEFAULT_KEY;
+
+	private BoundZSetOperations<String, String> zSetOperations;
+
+	private final RedisOperations<String, String> redisOperations;
+
+	/**
+	 * Create a RedisMetricRepository with a default prefix to apply to all metric names.
+	 * If multiple repositories share a redis instance they will feed into the same global
+	 * metrics.
+	 * @param redisConnectionFactory the redis connection factory
+	 */
+	public RedisMetricRepository(RedisConnectionFactory redisConnectionFactory) {
+		this(redisConnectionFactory, null);
+	}
+
+	/**
+	 * Create a RedisMetricRepository with a prefix to apply to all metric names (ideally
+	 * unique to this repository or to a logical repository contributed to by multiple
+	 * instances, where they all see the same values). Recommended constructor for general
+	 * purpose use.
+	 * @param redisConnectionFactory the redis connection factory
+	 * @param prefix the prefix to set for all metrics keys
+	 */
+	public RedisMetricRepository(RedisConnectionFactory redisConnectionFactory,
+								 String prefix) {
+		this(redisConnectionFactory, prefix, null);
+	}
+
+	/**
+	 * Allows user to set the prefix and key to use to store the index of other keys. The
+	 * redis store will hold a zset under the key just so the metric names can be
+	 * enumerated. Read operations, especially {@link #findAll()} and {@link #count()},
+	 * will only be accurate if the key is unique to the prefix of this repository.
+	 * @param redisConnectionFactory the redis connection factory
+	 * @param prefix the prefix to set for all metrics keys
+	 * @param key the key to set
+	 */
+	public RedisMetricRepository(RedisConnectionFactory redisConnectionFactory,
+								 String prefix, String key) {
+		if (prefix == null) {
+			prefix = DEFAULT_METRICS_PREFIX;
+			if (key == null) {
+				key = DEFAULT_KEY;
+			}
+		}
+		else if (key == null) {
+			key = "keys." + prefix;
+		}
+		Assert.notNull(redisConnectionFactory, "RedisConnectionFactory must not be null");
+		this.redisOperations = stringTemplate(redisConnectionFactory);
+		if (!prefix.endsWith(".")) {
+			prefix = prefix + ".";
+		}
+		this.prefix = prefix;
+		if (key.endsWith(".")) {
+			key = key.substring(0, key.length() - 1);
+		}
+		this.key = key;
+		this.zSetOperations = this.redisOperations.boundZSetOps(this.key);
+	}
+
+	static <K, V> RedisTemplate<K, V> createRedisTemplate(
+			RedisConnectionFactory connectionFactory, Class<V> valueClass) {
+		RedisTemplate<K, V> redisTemplate = new RedisTemplate<K, V>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericToStringSerializer<V>(valueClass));
+
+		// avoids proxy
+		redisTemplate.setExposeConnection(true);
+
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.afterPropertiesSet();
+		return redisTemplate;
+	}
+
+	static RedisOperations<String, String> stringTemplate(
+			RedisConnectionFactory redisConnectionFactory) {
+		return new StringRedisTemplate(redisConnectionFactory);
+	}
+
+	public Metric<?> findOne(String metricName) {
+		String redisKey = keyFor(metricName);
+		String raw = this.redisOperations.opsForValue().get(redisKey);
+		return deserialize(redisKey, raw, this.zSetOperations.score(redisKey));
+	}
+
+	public Iterable<Metric<?>> findAll() {
+
+		// This set is sorted
+		Set<String> keys = this.zSetOperations.range(0, -1);
+		Iterator<String> keysIt = keys.iterator();
+
+		List<Metric<?>> result = new ArrayList<Metric<?>>(keys.size());
+		List<String> values = this.redisOperations.opsForValue().multiGet(keys);
+		for (String v : values) {
+			String key = keysIt.next();
+			Metric<?> value = deserialize(key, v, this.zSetOperations.score(key));
+			if (value != null) {
+				result.add(value);
+			}
+		}
+		return result;
+
+	}
+
+	public long count() {
+		return this.zSetOperations.size();
+	}
+
+	public void increment(Delta<?> delta) {
+		String name = delta.getName();
+		String key = keyFor(name);
+		trackMembership(key);
+		double value = this.zSetOperations.incrementScore(key,
+				delta.getValue().doubleValue());
+		String raw = serialize(new Metric<Double>(name, value, delta.getTimestamp()));
+		this.redisOperations.opsForValue().set(key, raw);
+	}
+
+	public void set(Metric<?> value) {
+		String name = value.getName();
+		String key = keyFor(name);
+		trackMembership(key);
+		this.zSetOperations.add(key, value.getValue().doubleValue());
+		String raw = serialize(value);
+		this.redisOperations.opsForValue().set(key, raw);
+	}
+
+	public void reset(String metricName) {
+		String key = keyFor(metricName);
+		if (this.zSetOperations.remove(key) == 1) {
+			this.redisOperations.delete(key);
+		}
+	}
+
+	private Metric<?> deserialize(String redisKey, String v, Double value) {
+		if (redisKey == null || v == null || !redisKey.startsWith(this.prefix)) {
+			return null;
+		}
+		Date timestamp = new Date(Long.valueOf(v));
+		return new Metric<Double>(nameFor(redisKey), value, timestamp);
+	}
+
+	private String serialize(Metric<?> entity) {
+		return String.valueOf(entity.getTimestamp().getTime());
+	}
+
+	private String keyFor(String name) {
+		return this.prefix + name;
+	}
+
+	private String nameFor(String redisKey) {
+		return redisKey.substring(this.prefix.length());
+	}
+
+	private void trackMembership(String redisKey) {
+		this.zSetOperations.incrementScore(redisKey, 0.0D);
+	}
+
+}

--- a/src/main/java/org/springframework/analytics/rest/controller/AggregateCounterController.java
+++ b/src/main/java/org/springframework/analytics/rest/controller/AggregateCounterController.java
@@ -16,20 +16,13 @@
 
 package org.springframework.analytics.rest.controller;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.ReadablePeriod;
-
 import org.springframework.analytics.metrics.AggregateCounter;
 import org.springframework.analytics.metrics.AggregateCounterRepository;
 import org.springframework.analytics.metrics.AggregateCounterResolution;
 import org.springframework.analytics.rest.domain.AggregateCounterResource;
-import org.springframework.boot.actuate.endpoint.mvc.MetricsMvcEndpoint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -40,13 +33,12 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Allows interaction with Aggregate Counters.
@@ -71,31 +63,45 @@ public class AggregateCounterController {
 
 	/**
 	 * Retrieve information about a specific aggregate counter.
+	 *
+	 * @param name  counter name
+	 * @return {@link AggregateCounterResource}
+	 *
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	public AggregateCounterResource display(@PathVariable("name") String name) {
 		AggregateCounter counter = repository.findOne(name);
 		if (counter == null) {
-			throw new MetricsMvcEndpoint.NoSuchMetricException(name);
+			throw new IllegalArgumentException(name);
 		}
 		return deepAssembler.toResource(counter);
 	}
 
 	/**
 	 * Delete (reset) a specific counter.
+	 *
+	 * @param name counter name
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	protected void delete(@PathVariable("name") String name) {
 		AggregateCounter counter = repository.findOne(name);
 		if (counter == null) {
-			throw new MetricsMvcEndpoint.NoSuchMetricException(name);
+			throw new IllegalArgumentException(name);
 		}
 		repository.reset(name);
 	}
 
 	/**
 	 * List Counters that match the given criteria.
+	 *
+	 * @param pageable {@link Pageable}
+	 * @param pagedAssembler {@link PagedResourcesAssembler}
+	 * @param detailed detailed info
+	 * @param from from date
+ 	 * @param to to date
+	 * @param resolution {@link AggregateCounterResolution}
+	 * @return list counters
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	public PagedResources<AggregateCounterResource> list(
@@ -107,7 +113,7 @@ public class AggregateCounterController {
 		List<String> names = new ArrayList<>(repository.list());
 		long count = names.size();
 		long pageEnd = Math.min(count, pageable.getOffset() + pageable.getPageSize());
-		Page aggregateCounterPage = new PageImpl<>(names.subList(pageable.getOffset(), (int) pageEnd), pageable, names.size());
+		Page aggregateCounterPage = new PageImpl<>(names.subList((int)pageable.getOffset(), (int) pageEnd), pageable, names.size());
 		PagedResources<AggregateCounterResource> resources = pagedAssembler.toResource(aggregateCounterPage, shallowAssembler);
 		if (detailed) {
 			to = providedOrDefaultToValue(to);
@@ -131,6 +137,7 @@ public class AggregateCounterController {
 	 *                   buckets)
 	 * @param to         the end-time for the interval, default "now"
 	 * @param resolution the size of buckets to aggregate, <i>e.g.</i> hourly, daily, <i>etc.</i> (default "hour")
+	 * @return counts
 	 */
 	@ResponseBody
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/springframework/analytics/rest/controller/CounterController.java
+++ b/src/main/java/org/springframework/analytics/rest/controller/CounterController.java
@@ -16,14 +16,10 @@
 
 package org.springframework.analytics.rest.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.springframework.analytics.rest.domain.Metric;
+import org.springframework.analytics.metrics.redis.RedisMetricRepository;
 import org.springframework.analytics.rest.domain.CounterResource;
 import org.springframework.analytics.rest.domain.MetricResource;
-import org.springframework.boot.actuate.endpoint.mvc.MetricsMvcEndpoint;
-import org.springframework.boot.actuate.metrics.Metric;
-import org.springframework.boot.actuate.metrics.repository.MetricRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -34,12 +30,10 @@ import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.Assert;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Allows interaction with Counters.
@@ -55,7 +49,7 @@ public class CounterController {
 
 	public static final String COUNTER_PREFIX = "counter.";
 
-	private final MetricRepository metricRepository;
+	private final RedisMetricRepository metricRepository;
 
 	private final ResourceAssembler<Metric<Double>, CounterResource> counterResourceAssembler =
 			new DeepCounterResourceAssembler();
@@ -64,17 +58,22 @@ public class CounterController {
 			new ShallowMetricResourceAssembler();
 
 	/**
-	 * Create a {@link CounterController} that delegates to the provided {@link MetricRepository}.
+	 * Create a {@link CounterController} that delegates to the provided {@link RedisMetricRepository}.
 	 *
-	 * @param metricRepository the {@link MetricRepository} used by this controller
+	 * @param metricRepository the {@link RedisMetricRepository} used by this controller
 	 */
-	public CounterController(MetricRepository metricRepository) {
+	public CounterController(RedisMetricRepository metricRepository) {
 		Assert.notNull(metricRepository, "metricRepository must not be null");
 		this.metricRepository = metricRepository;
 	}
 
 	/**
 	 * List Counters that match the given criteria.
+	 *
+	 * @param pageable {@link Pageable}
+	 * @param pagedAssembler {@link PagedResourcesAssembler}
+	 * @param detailed details
+	 * @return {@link PagedResources}
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	public PagedResources<? extends MetricResource> list(
@@ -85,7 +84,7 @@ public class CounterController {
 		List<Metric<Double>> content = filterCounters(metrics);
 		long count = content.size();
 		long pageEnd = Math.min(count, pageable.getOffset() + pageable.getPageSize());
-		Page counterPage = new PageImpl<>(content.subList(pageable.getOffset(), (int) pageEnd), pageable, content.size());
+		Page counterPage = new PageImpl<>(content.subList((int)pageable.getOffset(), (int) pageEnd), pageable, content.size());
 		ResourceAssembler<Metric<Double>, ? extends MetricResource> assemblerToUse =
 				detailed ? counterResourceAssembler : shallowResourceAssembler;
 		return pagedAssembler.toResource(counterPage, assemblerToUse);
@@ -93,6 +92,9 @@ public class CounterController {
 
 	/**
 	 * Retrieve information about a specific counter.
+	 *
+	 * @param name name
+	 * @return counter information
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	public CounterResource display(@PathVariable("name") String name) {
@@ -102,6 +104,8 @@ public class CounterController {
 
 	/**
 	 * Delete (reset) a specific counter.
+	 *
+	 * @param name to delete
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
@@ -112,13 +116,16 @@ public class CounterController {
 
 	/**
 	 * Find a given counter, taking care of name conversion between the Spring Boot domain and our domain.
-	 * @throws MetricsMvcEndpoint.NoSuchMetricException if the counter does not exist
+	 *
+	 * @param name name
+	 * @return counter
+	 * @throws IllegalArgumentException if the counter does not exist
 	 */
 	private Metric<Double> findCounter(@PathVariable("name") String name) {
 		@SuppressWarnings("unchecked")
 		Metric<Double> c = (Metric<Double>) metricRepository.findOne(COUNTER_PREFIX + name);
 		if (c == null) {
-			throw new MetricsMvcEndpoint.NoSuchMetricException(name);
+			throw new IllegalArgumentException(name);
 		}
 		return c;
 	}

--- a/src/main/java/org/springframework/analytics/rest/controller/FieldValueCounterController.java
+++ b/src/main/java/org/springframework/analytics/rest/controller/FieldValueCounterController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,10 @@
 
 package org.springframework.analytics.rest.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.springframework.analytics.metrics.FieldValueCounter;
 import org.springframework.analytics.metrics.FieldValueCounterRepository;
-import org.springframework.analytics.rest.domain.AggregateCounterResource;
 import org.springframework.analytics.rest.domain.FieldValueCounterResource;
 import org.springframework.analytics.rest.domain.MetricResource;
-import org.springframework.boot.actuate.endpoint.mvc.MetricsMvcEndpoint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -33,11 +28,10 @@ import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Allows interaction with Field Value Counters.
@@ -62,31 +56,40 @@ public class FieldValueCounterController {
 
 	/**
 	 * Retrieve information about a specific counter.
+	 *
+	 * @param name name
+	 * @return counter information
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
 	public FieldValueCounterResource display(@PathVariable("name") String name) {
 		FieldValueCounter counter = repository.findOne(name);
 		if (counter == null) {
-			throw new MetricsMvcEndpoint.NoSuchMetricException(name);
+			throw new IllegalArgumentException(name);
 		}
 		return deepAssembler.toResource(counter);
 	}
 
 	/**
 	 * Delete (reset) a specific counter.
+	 *
+	 * @param name name
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	protected void delete(@PathVariable("name") String name) {
 		FieldValueCounter counter = repository.findOne(name);
 		if (counter == null) {
-			throw new MetricsMvcEndpoint.NoSuchMetricException(name);
+			throw new IllegalArgumentException(name);
 		}
 		repository.reset(name);
 	}
 
 	/**
 	 * List Counters that match the given criteria.
+	 *
+	 * @param pageable {@link Pageable}
+	 * @param pagedAssembler {@link PagedResourcesAssembler}
+	 * @return counters
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	public PagedResources<? extends MetricResource> list(Pageable pageable,
@@ -94,7 +97,7 @@ public class FieldValueCounterController {
 		List<String> names = new ArrayList<>(repository.list());
 		long count = names.size();
 		long pageEnd = Math.min(count, pageable.getOffset() + pageable.getPageSize());
-		Page fieldValueCounterPage = new PageImpl<>(names.subList(pageable.getOffset(), (int) pageEnd), pageable, names.size());
+		Page fieldValueCounterPage = new PageImpl<>(names.subList((int)pageable.getOffset(), (int) pageEnd), pageable, names.size());
 		return pagedAssembler.toResource(fieldValueCounterPage, shallowAssembler);
 	}
 

--- a/src/main/java/org/springframework/analytics/rest/domain/AggregateCounterResource.java
+++ b/src/main/java/org/springframework/analytics/rest/domain/AggregateCounterResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,13 @@
 
 package org.springframework.analytics.rest.domain;
 
-import java.util.Date;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /**
  * The REST representation of an Aggregate Count.
@@ -49,13 +48,16 @@ public class AggregateCounterResource extends MetricResource {
 
 	/**
 	 * Add a data point to the set.
+	 *
+	 * @param when date
+	 * @param value to set
 	 */
 	public void addValue(Date when, long value) {
 		values.put(when, value);
 	}
 
 	/**
-	 * Returns a date-sorted view of counts.
+	 * @return a date-sorted view of counts.
 	 */
 	public SortedMap<Date, Long> getValues() {
 		return values;

--- a/src/main/java/org/springframework/analytics/rest/domain/Delta.java
+++ b/src/main/java/org/springframework/analytics/rest/domain/Delta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,38 +16,22 @@
 
 package org.springframework.analytics.rest.domain;
 
+import java.util.Date;
+
 /**
- * The REST representation of a Counter.
+ * A value object representing an increment in a metric value (usually a counter).
  *
- * @author Eric Bottard
+ * @param <T> the value type
+ * @author Dave Syer
  */
-public class CounterResource extends MetricResource {
+public class Delta<T extends Number> extends Metric<T> {
 
-	/**
-	 * The value for the counter.
-	 */
-	private long value;
-
-
-	/**
-	 * No-arg constructor for serialization frameworks.
-	 */
-	protected CounterResource() {
-
+	public Delta(String name, T value, Date timestamp) {
+		super(name, value, timestamp);
 	}
 
-	public CounterResource(String name, long value) {
-		super(name);
-		this.value = value;
-	}
-
-	/**
-	 * Return the value for the counter.
-	 *
-	 * @return counter value
-	 */
-	public long getValue() {
-		return value;
+	public Delta(String name, T value) {
+		super(name, value);
 	}
 
 }

--- a/src/main/java/org/springframework/analytics/rest/domain/FieldValueCounterResource.java
+++ b/src/main/java/org/springframework/analytics/rest/domain/FieldValueCounterResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.analytics.rest.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Comparator;
 import java.util.Map;
 import java.util.TreeMap;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The REST representation of a Field Value Counter.
@@ -49,6 +49,8 @@ public class FieldValueCounterResource extends MetricResource {
 
 	/**
 	 * Return the values for the counter.
+	 *
+	 * @return counter values
 	 */
 	public Map<String, Double> getValues() {
 		return values;

--- a/src/main/java/org/springframework/analytics/rest/domain/Metric.java
+++ b/src/main/java/org/springframework/analytics/rest/domain/Metric.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.analytics.rest.domain;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Date;
+
+/**
+ * Immutable class that can be used to hold any arbitrary system measurement value (a
+ * named numeric value with a timestamp). For example a metric might record the number of
+ * active connections to a server, or the temperature of a meeting room.
+ *
+ * @param <T> the value type
+ * @author Dave Syer
+ */
+public class Metric<T extends Number> {
+
+	private final String name;
+
+	private final T value;
+
+	private final Date timestamp;
+
+	/**
+	 * Create a new {@link Metric} instance for the current time.
+	 * @param name the name of the metric
+	 * @param value the value of the metric
+	 */
+	public Metric(String name, T value) {
+		this(name, value, new Date());
+	}
+
+	/**
+	 * Create a new {@link Metric} instance.
+	 * @param name the name of the metric
+	 * @param value the value of the metric
+	 * @param timestamp the timestamp for the metric
+	 */
+	public Metric(String name, T value, Date timestamp) {
+		Assert.notNull(name, "Name must not be null");
+		this.name = name;
+		this.value = value;
+		this.timestamp = timestamp;
+	}
+
+	/**
+	 * Returns the name of the metric.
+	 * @return the name
+	 */
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Returns the value of the metric.
+	 * @return the value
+	 */
+	public T getValue() {
+		return this.value;
+	}
+
+	public Date getTimestamp() {
+		return this.timestamp;
+	}
+
+	@Override
+	public String toString() {
+		return "Metric [name=" + this.name + ", value=" + this.value + ", timestamp="
+				+ this.timestamp + "]";
+	}
+
+	/**
+	 * Create a new {@link Metric} with an incremented value.
+	 * @param amount the amount that the new metric will differ from this one
+	 * @return a new {@link Metric} instance
+	 */
+	public Metric<Long> increment(int amount) {
+		return new Metric<Long>(this.getName(),
+				Long.valueOf(this.getValue().longValue() + amount));
+	}
+
+	/**
+	 * Create a new {@link Metric} with a different value.
+	 * @param <S> the metric value type
+	 * @param value the value of the new metric
+	 * @return a new {@link Metric} instance
+	 */
+	public <S extends Number> Metric<S> set(S value) {
+		return new Metric<S>(this.getName(), value);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.name);
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.timestamp);
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.value);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (obj instanceof Metric) {
+			Metric<?> other = (Metric<?>) obj;
+			boolean rtn = true;
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.name, other.name);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.timestamp, other.timestamp);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.value, other.value);
+			return rtn;
+		}
+		return super.equals(obj);
+	}
+
+}

--- a/src/main/java/org/springframework/analytics/rest/domain/MetricResource.java
+++ b/src/main/java/org/springframework/analytics/rest/domain/MetricResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -41,6 +41,8 @@ public class MetricResource extends ResourceSupport {
 
 	/**
 	 * Return the name of the metric.
+	 *
+	 * @return name of the metric
 	 */
 	public String getName() {
 		return name;

--- a/src/test/java/org/springframework/analytics/test/support/AbstractExternalResourceTestSupport.java
+++ b/src/test/java/org/springframework/analytics/test/support/AbstractExternalResourceTestSupport.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.analytics.test;
-
-import static org.junit.Assert.fail;
+package org.springframework.analytics.test.support;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,8 +23,9 @@ import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
 import org.springframework.util.Assert;
+
+import static org.junit.Assert.fail;
 
 /**
  * Abstract base class for JUnit {@link Rule}s that detect the presence of some external

--- a/src/test/java/org/springframework/analytics/test/support/CounterService.java
+++ b/src/test/java/org/springframework/analytics/test/support/CounterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,40 +14,31 @@
  * limitations under the License.
  */
 
-package org.springframework.analytics.rest.domain;
+package org.springframework.analytics.test.support;
 
 /**
- * The REST representation of a Counter.
+ * A service that can be used to increment, decrement and reset a named counter value.
  *
- * @author Eric Bottard
+ * @author Dave Syer
  */
-public class CounterResource extends MetricResource {
+public interface CounterService {
 
 	/**
-	 * The value for the counter.
+	 * Increment the specified counter by 1.
+	 * @param metricName the name of the counter
 	 */
-	private long value;
-
+	void increment(String metricName);
 
 	/**
-	 * No-arg constructor for serialization frameworks.
+	 * Decrement the specified counter by 1.
+	 * @param metricName the name of the counter
 	 */
-	protected CounterResource() {
-
-	}
-
-	public CounterResource(String name, long value) {
-		super(name);
-		this.value = value;
-	}
+	void decrement(String metricName);
 
 	/**
-	 * Return the value for the counter.
-	 *
-	 * @return counter value
+	 * Reset the specified counter.
+	 * @param metricName the name of the counter
 	 */
-	public long getValue() {
-		return value;
-	}
+	void reset(String metricName);
 
 }

--- a/src/test/java/org/springframework/analytics/test/support/DefaultCounterService.java
+++ b/src/test/java/org/springframework/analytics/test/support/DefaultCounterService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.analytics.test.support;
+
+import org.springframework.analytics.metrics.redis.RedisMetricRepository;
+import org.springframework.analytics.rest.domain.Delta;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default implementation of {@link CounterService}.
+ *
+ * @author Dave Syer
+ */
+public class DefaultCounterService implements CounterService {
+
+	private final RedisMetricRepository writer;
+
+	private final ConcurrentHashMap<String, String> names = new ConcurrentHashMap<String, String>();
+
+	/**
+	 * Create a {@link DefaultCounterService} instance.
+	 * @param writer the underlying writer used to manage metrics
+	 */
+	public DefaultCounterService(RedisMetricRepository writer) {
+		this.writer = writer;
+	}
+
+	@Override
+	public void increment(String metricName) {
+		this.writer.increment(new Delta<Long>(wrap(metricName), 1L));
+	}
+
+	@Override
+	public void decrement(String metricName) {
+		this.writer.increment(new Delta<Long>(wrap(metricName), -1L));
+	}
+
+	@Override
+	public void reset(String metricName) {
+		this.writer.reset(wrap(metricName));
+	}
+
+	private String wrap(String metricName) {
+		String cached = this.names.get(metricName);
+		if (cached != null) {
+			return cached;
+		}
+		if (metricName.startsWith("counter.") || metricName.startsWith("meter.")) {
+			return metricName;
+		}
+		String name = "counter." + metricName;
+		this.names.put(metricName, name);
+		return name;
+	}
+
+}

--- a/src/test/java/org/springframework/analytics/test/support/RedisTestSupport.java
+++ b/src/test/java/org/springframework/analytics/test/support/RedisTestSupport.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package org.springframework.analytics.test;
+package org.springframework.analytics.test.support;
 
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 /**
  * JUnit {@link org.junit.Rule} that detects the fact that a Redis server is running on localhost.
@@ -24,7 +24,7 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
  * @author Gary Russell
  * @author Eric Bottard
  */
-public class RedisTestSupport extends AbstractExternalResourceTestSupport<JedisConnectionFactory> {
+public class RedisTestSupport extends AbstractExternalResourceTestSupport<LettuceConnectionFactory> {
 
 	public RedisTestSupport() {
 		super("REDIS");
@@ -32,7 +32,7 @@ public class RedisTestSupport extends AbstractExternalResourceTestSupport<JedisC
 
 	@Override
 	protected void obtainResource() throws Exception {
-		resource = new JedisConnectionFactory();
+		resource = new LettuceConnectionFactory();
 		resource.afterPropertiesSet();
 		resource.getConnection().close();
 	}


### PR DESCRIPTION
 - Migrate necessary metrics related classes removed in Boot 2.0 over to spring-analytics - Metric, Delta and RedisMetricRepository
 - Migrage classes used for tests - CounterService and DefaultCounterService
 - Isolating changes in spring-analytics so that it doesn't need micrometer libs to address analytics
 - Removed the need for MvcEndpoint based exceptions - simply use IllegalArgumentException
 - Test changes
 - Polishing

Resolves #11